### PR TITLE
chore: Update GitHub Actions cache to latest version

### DIFF
--- a/.github/actions/php-environment/action.yml
+++ b/.github/actions/php-environment/action.yml
@@ -35,7 +35,7 @@ runs:
       run: echo "::set-output name=directory::$(composer config cache-files-dir)"
 
     - name: Cache dependencies installed with composer
-      uses: "actions/cache@v2.0.0"
+      uses: "actions/cache@v4.0.0"
       with:
         path: "${{ steps.composer-cache.outputs.directory }}"
         key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"


### PR DESCRIPTION
Upgrade the actions/cache action from v2.0.0 to v4.0.0 in the PHP environment GitHub Actions workflow